### PR TITLE
Automatically call sudo if necessary

### DIFF
--- a/enable-ius.sh
+++ b/enable-ius.sh
@@ -3,6 +3,13 @@
 # Script to setup the IUS public repository on your EL server.
 # Tested on CentOS/RHEL 6/7.
 
+# Automatically call sudo as needed if running as non-root user
+if [[ $(id -u) -ne 0 && $(id -r -u) -ne 0 ]]; then
+	PLEASE="sudo"
+else
+	PLEASE=""
+fi
+
 supported_version_check(){
 	case ${RELEASE} in
 		6*) echo "EL 6 is supported" ;;
@@ -16,43 +23,43 @@ supported_version_check(){
 
 centos_install_epel(){
 	# CentOS has epel release in the extras repo
-	yum -y install epel-release
+	$PLEASE yum -y install epel-release
 	import_epel_key
 }
 
 rhel_install_epel(){
 	case ${RELEASE} in
-		6*) yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm;;
-		7*) yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm;;
+		6*) $PLEASE yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm;;
+		7*) $PLEASE yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm;;
 	esac
 	import_epel_key
 }
 
 import_epel_key(){
 	case ${RELEASE} in
-		6*) rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6;;
-		7*) rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7;;
+		6*) $PLEASE rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6;;
+		7*) $PLEASE rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7;;
 	esac
 }
 
 centos_install_ius(){
 	case ${RELEASE} in
-		6*) yum -y install https://centos6.iuscommunity.org/ius-release.rpm;;
-		7*) yum -y install https://centos7.iuscommunity.org/ius-release.rpm;;
+		6*) $PLEASE yum -y install https://centos6.iuscommunity.org/ius-release.rpm;;
+		7*) $PLEASE yum -y install https://centos7.iuscommunity.org/ius-release.rpm;;
 	esac
 	import_ius_key
 }
 
 rhel_install_ius(){
 	case ${RELEASE} in
-		6*) yum -y install https://rhel6.iuscommunity.org/ius-release.rpm;;
-		7*) yum -y install https://rhel7.iuscommunity.org/ius-release.rpm;;
+		6*) $PLEASE yum -y install https://rhel6.iuscommunity.org/ius-release.rpm;;
+		7*) $PLEASE yum -y install https://rhel7.iuscommunity.org/ius-release.rpm;;
 	esac
 	import_ius_key
 }
 
 import_ius_key(){
-	rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
+	$PLEASE rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
 }
 
 if [[ -e /etc/redhat-release ]]; then

--- a/enable-ius.sh
+++ b/enable-ius.sh
@@ -3,6 +3,12 @@
 # Script to setup the IUS public repository on your EL server.
 # Tested on CentOS/RHEL 6/7.
 
+set -o errexit
+if [[ ${UID} -ne 0 && ${EUID} -ne 0 ]]; then
+	echo "Error, this script requires root privileges." >&2
+	exit 1
+fi
+
 supported_version_check(){
 	case ${RELEASE} in
 		6*) echo "EL 6 is supported" ;;

--- a/enable-ius.sh
+++ b/enable-ius.sh
@@ -3,13 +3,6 @@
 # Script to setup the IUS public repository on your EL server.
 # Tested on CentOS/RHEL 6/7.
 
-# Automatically call sudo as needed if running as non-root user
-if [[ $(id -u) -ne 0 && $(id -r -u) -ne 0 ]]; then
-	PLEASE="sudo"
-else
-	PLEASE=""
-fi
-
 supported_version_check(){
 	case ${RELEASE} in
 		6*) echo "EL 6 is supported" ;;
@@ -23,43 +16,43 @@ supported_version_check(){
 
 centos_install_epel(){
 	# CentOS has epel release in the extras repo
-	$PLEASE yum -y install epel-release
+	yum -y install epel-release
 	import_epel_key
 }
 
 rhel_install_epel(){
 	case ${RELEASE} in
-		6*) $PLEASE yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm;;
-		7*) $PLEASE yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm;;
+		6*) yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm;;
+		7*) yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm;;
 	esac
 	import_epel_key
 }
 
 import_epel_key(){
 	case ${RELEASE} in
-		6*) $PLEASE rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6;;
-		7*) $PLEASE rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7;;
+		6*) rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6;;
+		7*) rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7;;
 	esac
 }
 
 centos_install_ius(){
 	case ${RELEASE} in
-		6*) $PLEASE yum -y install https://centos6.iuscommunity.org/ius-release.rpm;;
-		7*) $PLEASE yum -y install https://centos7.iuscommunity.org/ius-release.rpm;;
+		6*) yum -y install https://centos6.iuscommunity.org/ius-release.rpm;;
+		7*) yum -y install https://centos7.iuscommunity.org/ius-release.rpm;;
 	esac
 	import_ius_key
 }
 
 rhel_install_ius(){
 	case ${RELEASE} in
-		6*) $PLEASE yum -y install https://rhel6.iuscommunity.org/ius-release.rpm;;
-		7*) $PLEASE yum -y install https://rhel7.iuscommunity.org/ius-release.rpm;;
+		6*) yum -y install https://rhel6.iuscommunity.org/ius-release.rpm;;
+		7*) yum -y install https://rhel7.iuscommunity.org/ius-release.rpm;;
 	esac
 	import_ius_key
 }
 
 import_ius_key(){
-	$PLEASE rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
+	rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
 }
 
 if [[ -e /etc/redhat-release ]]; then


### PR DESCRIPTION
Modify `enable-ius.sh` to call `sudo` as needed if running as a non-root user. 
