### PR TITLE
Update enable-ius.sh

### DIFF
--- a/enable-ius.sh
+++ b/enable-ius.sh
@@ -58,7 +58,10 @@ rhel_install_ius(){
 }
 
 import_ius_key(){
-	rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY
+	case ${RELEASE} in 
+		6*) rpm --import /etc/pki/rpm-gpg/IUS-COMMUNITY-GPG-KEY;;
+		7*) rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-IUS-7;;
+	esac
 }
 
 if [[ -e /etc/redhat-release ]]; then


### PR DESCRIPTION
I haven't tested this, 
but I have to assume Release 6 used IUS-COMMUNITY-GPG-KEY
and Release 7 used RPM-GPG-KEY-IUS-7

